### PR TITLE
Add player home world for better identification of players

### DIFF
--- a/src/Kapture.Test/Mocks/KapturePluginMock.cs
+++ b/src/Kapture.Test/Mocks/KapturePluginMock.cs
@@ -84,6 +84,12 @@ namespace Kapture.Test
         {
             return "Pika Chu";
         }
+        
+        /// <inheritdoc />
+        public string GetLocalPlayerWorld()
+        {
+            return "Pandaemonium";
+        }
 
         /// <inheritdoc />
         public ushort ClientLanguage()

--- a/src/Kapture/Kapture/Model/LootEvent.cs
+++ b/src/Kapture/Kapture/Model/LootEvent.cs
@@ -41,6 +41,11 @@ namespace Kapture
         public string PlayerName { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets player home world name.
+        /// </summary>
+        public string World { get; set; } = string.Empty;
+
+        /// <summary>
         /// Gets or sets player display name.
         /// </summary>
         public string PlayerDisplayName { get; set; } = string.Empty;
@@ -93,6 +98,7 @@ namespace Kapture
                 "ItemName",
                 "IsHQ",
                 "PlayerName",
+                "World",
                 "Roll",
             });
         }
@@ -120,6 +126,7 @@ namespace Kapture
                 this.LootMessage.ItemName,
                 this.LootMessage.IsHq.ToString(),
                 this.PlayerName,
+                this.World,
                 this.Roll.ToString(),
             });
         }

--- a/src/Kapture/Kapture/Model/LootMessage.cs
+++ b/src/Kapture/Kapture/Model/LootMessage.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 
+using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Lumina.Excel.GeneratedSheets;
 using Newtonsoft.Json;
 
@@ -60,6 +61,12 @@ namespace Kapture
         /// </summary>
         [JsonIgnore]
         public Item Item { get; set; } = null!;
+
+        /// <summary>
+        /// Gets or sets playerPayload.
+        /// </summary>
+        [JsonIgnore]
+        public PlayerPayload? Player { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether hq.

--- a/src/Kapture/Kapture/Plugin/Plugin/IKapturePlugin.cs
+++ b/src/Kapture/Kapture/Plugin/Plugin/IKapturePlugin.cs
@@ -74,6 +74,12 @@ namespace Kapture
         string GetLocalPlayerName();
 
         /// <summary>
+        /// Get local player home world name.
+        /// </summary>
+        /// <returns>local player home world name.</returns>
+        string GetLocalPlayerWorld();
+
+        /// <summary>
         /// Client language.
         /// </summary>
         /// <returns>client language.</returns>

--- a/src/Kapture/Kapture/Plugin/Plugin/KapturePlugin.cs
+++ b/src/Kapture/Kapture/Plugin/Plugin/KapturePlugin.cs
@@ -229,6 +229,12 @@ namespace Kapture
         }
 
         /// <inheritdoc />
+        public string GetLocalPlayerWorld()
+        {
+            return ClientState.LocalPlayer?.HomeWorld.GameData.Name.ToString() ?? string.Empty;
+        }
+
+        /// <inheritdoc />
         public ushort ClientLanguage()
         {
             return (ushort)ClientState.ClientLanguage;
@@ -524,6 +530,10 @@ namespace Kapture
                         lootMessage.ItemName = itemPayload.Item.Name.ToString();
                         lootMessage.Item = itemPayload.Item;
                         lootMessage.IsHq = itemPayload.IsHQ;
+                        break;
+                    case PlayerPayload playerPayload:
+                        if (lootMessage.Player is not null) break;
+                        lootMessage.Player = playerPayload;
                         break;
                 }
             }

--- a/src/Kapture/Kapture/Service/LootProcessor/DELootProcessor.cs
+++ b/src/Kapture/Kapture/Service/LootProcessor/DELootProcessor.cs
@@ -60,6 +60,7 @@ namespace Kapture
                     LootEventType = LootEventType.Search,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -89,6 +90,7 @@ namespace Kapture
                     LootEventType = LootEventType.Purchase,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -100,6 +102,7 @@ namespace Kapture
                     LootEventType = LootEventType.Discard,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -111,6 +114,7 @@ namespace Kapture
                     LootEventType = LootEventType.Obtain,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -122,6 +126,7 @@ namespace Kapture
                     LootEventType = LootEventType.Obtain,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -133,6 +138,7 @@ namespace Kapture
                     LootEventType = LootEventType.Lost,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -148,6 +154,7 @@ namespace Kapture
                 LootEventType = LootEventType.Obtain,
                 IsLocalPlayer = true,
                 PlayerName = this.Plugin.GetLocalPlayerName(),
+                World = this.Plugin.GetLocalPlayerWorld(),
             };
         }
 
@@ -158,6 +165,7 @@ namespace Kapture
             {
                 IsLocalPlayer = true,
                 PlayerName = this.Plugin.GetLocalPlayerName(),
+                World = this.Plugin.GetLocalPlayerWorld(),
             };
 
             // Cast Lot (Local Player)
@@ -196,6 +204,7 @@ namespace Kapture
                 LootEventType = LootEventType.Obtain,
                 IsLocalPlayer = false,
                 PlayerName = message.MessageParts[0],
+                World = message.Player?.World.Name.ToString() ?? string.Empty,
             };
         }
 
@@ -206,6 +215,7 @@ namespace Kapture
             {
                 IsLocalPlayer = false,
                 PlayerName = message.MessageParts[0],
+                World = message.Player?.World.Name.ToString() ?? string.Empty,
             };
 
             // Cast Lot (Other Player)
@@ -246,6 +256,7 @@ namespace Kapture
                     LootEventType = LootEventType.Desynth,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -257,6 +268,7 @@ namespace Kapture
                     LootEventType = LootEventType.Use,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -268,6 +280,7 @@ namespace Kapture
                     LootEventType = LootEventType.Sell,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -283,6 +296,7 @@ namespace Kapture
                 LootEventType = LootEventType.Use,
                 IsLocalPlayer = true,
                 PlayerName = this.Plugin.GetLocalPlayerName(),
+                World = this.Plugin.GetLocalPlayerWorld(),
             };
         }
 
@@ -295,6 +309,7 @@ namespace Kapture
                 LootEventType = LootEventType.Obtain,
                 IsLocalPlayer = true,
                 PlayerName = this.Plugin.GetLocalPlayerName(),
+                World = this.Plugin.GetLocalPlayerWorld(),
             };
         }
 
@@ -308,6 +323,7 @@ namespace Kapture
                 {
                     LootEventType = LootEventType.Use,
                     PlayerName = message.MessageParts[0],
+                    World = message.Player?.World.Name.ToString() ?? string.Empty,
                 };
             }
 
@@ -325,6 +341,7 @@ namespace Kapture
                     LootEventType = LootEventType.Use,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -336,6 +353,7 @@ namespace Kapture
                     LootEventType = LootEventType.Obtain,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -347,6 +365,7 @@ namespace Kapture
                     LootEventType = LootEventType.Craft,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -364,6 +383,7 @@ namespace Kapture
                     LootEventType = LootEventType.Gather,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -375,6 +395,7 @@ namespace Kapture
                     LootEventType = LootEventType.Gather,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -392,6 +413,7 @@ namespace Kapture
                     LootEventType = LootEventType.Craft,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -408,6 +430,7 @@ namespace Kapture
                 {
                     LootEventType = LootEventType.Craft,
                     PlayerName = message.MessageParts[0],
+                    World = message.Player?.World.Name.ToString() ?? string.Empty,
                 };
             }
 

--- a/src/Kapture/Kapture/Service/LootProcessor/ENLootProcessor.cs
+++ b/src/Kapture/Kapture/Service/LootProcessor/ENLootProcessor.cs
@@ -60,6 +60,7 @@ namespace Kapture
                     LootEventType = LootEventType.Search,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -89,6 +90,7 @@ namespace Kapture
                     LootEventType = LootEventType.Purchase,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -100,6 +102,7 @@ namespace Kapture
                     LootEventType = LootEventType.Discard,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -111,6 +114,7 @@ namespace Kapture
                     LootEventType = LootEventType.Obtain,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -122,6 +126,7 @@ namespace Kapture
                     LootEventType = LootEventType.Obtain,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -133,6 +138,7 @@ namespace Kapture
                     LootEventType = LootEventType.Lost,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -148,6 +154,7 @@ namespace Kapture
                 LootEventType = LootEventType.Obtain,
                 IsLocalPlayer = true,
                 PlayerName = this.Plugin.GetLocalPlayerName(),
+                World = this.Plugin.GetLocalPlayerWorld(),
             };
         }
 
@@ -184,6 +191,7 @@ namespace Kapture
             }
 
             lootEvent.PlayerName = this.Plugin.GetLocalPlayerName();
+            lootEvent.World = this.Plugin.GetLocalPlayerWorld();
 
             return lootEvent;
         }
@@ -197,6 +205,7 @@ namespace Kapture
                 LootEventType = LootEventType.Obtain,
                 IsLocalPlayer = false,
                 PlayerName = message.MessageParts.First(),
+                World = message.Player?.World.Name.ToString() ?? string.Empty,
             };
         }
 
@@ -207,6 +216,7 @@ namespace Kapture
             {
                 IsLocalPlayer = false,
                 PlayerName = message.MessageParts.First(),
+                World = message.Player?.World.Name.ToString() ?? string.Empty,
             };
 
             // Cast Lot (Other Player)
@@ -247,6 +257,7 @@ namespace Kapture
                     LootEventType = LootEventType.Desynth,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -258,6 +269,7 @@ namespace Kapture
                     LootEventType = LootEventType.Use,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -269,6 +281,7 @@ namespace Kapture
                     LootEventType = LootEventType.Sell,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -284,6 +297,7 @@ namespace Kapture
                 LootEventType = LootEventType.Use,
                 IsLocalPlayer = true,
                 PlayerName = this.Plugin.GetLocalPlayerName(),
+                World = this.Plugin.GetLocalPlayerWorld(),
             };
         }
 
@@ -296,6 +310,7 @@ namespace Kapture
                 LootEventType = LootEventType.Obtain,
                 IsLocalPlayer = true,
                 PlayerName = this.Plugin.GetLocalPlayerName(),
+                World = this.Plugin.GetLocalPlayerWorld(),
             };
         }
 
@@ -309,6 +324,7 @@ namespace Kapture
                 {
                     LootEventType = LootEventType.Use,
                     PlayerName = message.MessageParts.First(),
+                    World = message.Player?.World.Name.ToString() ?? string.Empty,
                 };
             }
 
@@ -326,6 +342,7 @@ namespace Kapture
                     LootEventType = LootEventType.Use,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -337,6 +354,7 @@ namespace Kapture
                     LootEventType = LootEventType.Obtain,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -348,6 +366,7 @@ namespace Kapture
                     LootEventType = LootEventType.Craft,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -365,6 +384,7 @@ namespace Kapture
                     LootEventType = LootEventType.Gather,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -376,6 +396,7 @@ namespace Kapture
                     LootEventType = LootEventType.Gather,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -393,6 +414,7 @@ namespace Kapture
                     LootEventType = LootEventType.Craft,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -409,6 +431,7 @@ namespace Kapture
                 {
                     LootEventType = LootEventType.Craft,
                     PlayerName = message.MessageParts.First(),
+                    World = message.Player?.World.Name.ToString() ?? string.Empty,
                 };
             }
 

--- a/src/Kapture/Kapture/Service/LootProcessor/ZHLootProcessor.cs
+++ b/src/Kapture/Kapture/Service/LootProcessor/ZHLootProcessor.cs
@@ -70,6 +70,7 @@ namespace Kapture
                     LootEventType = LootEventType.Search,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -99,6 +100,7 @@ namespace Kapture
                     LootEventType = LootEventType.Purchase,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -110,6 +112,7 @@ namespace Kapture
                     LootEventType = LootEventType.Discard,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -121,6 +124,7 @@ namespace Kapture
                     LootEventType = LootEventType.Obtain,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -132,6 +136,7 @@ namespace Kapture
                     LootEventType = LootEventType.Obtain,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -143,6 +148,7 @@ namespace Kapture
                     LootEventType = LootEventType.Lost,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -154,6 +160,7 @@ namespace Kapture
                     LootEventType = LootEventType.Sell,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -169,6 +176,7 @@ namespace Kapture
                 LootEventType = LootEventType.Obtain,
                 IsLocalPlayer = true,
                 PlayerName = this.Plugin.GetLocalPlayerName(),
+                World = this.Plugin.GetLocalPlayerWorld(),
             };
         }
 
@@ -179,6 +187,7 @@ namespace Kapture
             {
                 IsLocalPlayer = true,
                 PlayerName = this.Plugin.GetLocalPlayerName(),
+                World = this.Plugin.GetLocalPlayerWorld(),
             };
 
             // Cast Lot (Local Player)
@@ -217,6 +226,7 @@ namespace Kapture
                 LootEventType = LootEventType.Obtain,
                 IsLocalPlayer = false,
                 PlayerName = message.MessageParts[0],
+                World = message.Player?.World.Name.ToString() ?? string.Empty,
             };
         }
 
@@ -227,6 +237,7 @@ namespace Kapture
             {
                 IsLocalPlayer = false,
                 PlayerName = message.MessageParts[0],
+                World = message.Player?.World.Name.ToString() ?? string.Empty,
             };
 
             // Cast Lot (Other Player)
@@ -267,6 +278,7 @@ namespace Kapture
                     LootEventType = LootEventType.Desynth,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -278,6 +290,7 @@ namespace Kapture
                     LootEventType = LootEventType.Use,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -293,6 +306,7 @@ namespace Kapture
                 LootEventType = LootEventType.Use,
                 IsLocalPlayer = true,
                 PlayerName = this.Plugin.GetLocalPlayerName(),
+                World = this.Plugin.GetLocalPlayerWorld(),
             };
         }
 
@@ -305,6 +319,7 @@ namespace Kapture
                 LootEventType = LootEventType.Obtain,
                 IsLocalPlayer = true,
                 PlayerName = this.Plugin.GetLocalPlayerName(),
+                World = this.Plugin.GetLocalPlayerWorld(),
             };
         }
 
@@ -318,6 +333,7 @@ namespace Kapture
                 {
                     LootEventType = LootEventType.Use,
                     PlayerName = message.MessageParts[0],
+                    World = message.Player?.World.Name.ToString() ?? string.Empty,
                 };
             }
 
@@ -335,6 +351,7 @@ namespace Kapture
                     LootEventType = LootEventType.Use,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -346,6 +363,7 @@ namespace Kapture
                     LootEventType = LootEventType.Obtain,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -358,6 +376,7 @@ namespace Kapture
                     LootEventType = LootEventType.Craft,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -375,6 +394,7 @@ namespace Kapture
                     LootEventType = LootEventType.Gather,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -386,6 +406,7 @@ namespace Kapture
                     LootEventType = LootEventType.Gather,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -404,6 +425,7 @@ namespace Kapture
                     LootEventType = LootEventType.Craft,
                     IsLocalPlayer = true,
                     PlayerName = this.Plugin.GetLocalPlayerName(),
+                    World = this.Plugin.GetLocalPlayerWorld(),
                 };
             }
 
@@ -422,6 +444,7 @@ namespace Kapture
                 {
                     LootEventType = LootEventType.Craft,
                     PlayerName = message.MessageParts[0],
+                    World = message.Player?.World.Name.ToString() ?? string.Empty,
                 };
             }
 


### PR DESCRIPTION
PR for #24
- If a chat message contains a PlayerPayload, the first occurrence is used to set the home world of the involved player.
- The player world data from Dalamud is used for LootEvent involving the local player.
- As a fallback the value is set to an empty string.

I have only added the home world name, because the id can be derived from the name.


